### PR TITLE
compat: change crate edition to 2015

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rle-decode-helper"
 version = "1.0.0-alpha2"
 authors = ["Moritz Wanzenböck <moritz@wanzenbug.xyz>"]
-edition = "2018"
+edition = "2015"
 license = "MIT OR Apache-2.0"
 description = """
 THE fastest way to implement any kind of decoding for Run Length Encoded data in Rust.


### PR DESCRIPTION
Stay compatible with compilers before editions were introduced.
This change ensures that no new syntax features are used when using
up-to-date compilers. the edition key is ignored with older
toolchains, so they work out-of-the-box.

Fixes #2 