### PR TITLE
Add #[inline(always)] to append_from_within()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ pub fn rle_decode_simple<T>(
 ///
 /// Note that the generic bounds were replaced by an explicit a..b range.
 /// This is so that we can compile this on older toolchains (< 1.28).
+#[inline(always)]
 fn append_from_within<T>(seif: &mut Vec<T>, src: ops::Range<usize>) where T: Copy, {
     assert!(src.start <= src.end, "src end is before src start");
     assert!(src.end <= seif.len(), "src is out of bounds");


### PR DESCRIPTION
This is crucial for eliding bounds checks and makes a measurable performance difference, even for _simple function that would get two copies this way